### PR TITLE
Add .kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: server
+    run_list:
+      - recipe[npm_lazy::server]
+    attributes:
+
+  - name: client
+    run_list:
+      - recipe[npm_lazy::client]
+    attributes:
+      npm_lazy:
+        client:
+          install_nodejs: true

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'
+
+# Uncomment these lines if you want to live on the Edge:
+#
+# group :development do
+#   gem "berkshelf", github: "berkshelf/berkshelf"
+#   gem "vagrant", github: "mitchellh/vagrant", tag: "v1.6.3"
+# end
+#
+# group :plugins do
+#   gem "vagrant-berkshelf", github: "berkshelf/vagrant-berkshelf"
+#   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
+# end
+
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'berkshelf/thor'
+
+begin
+  require "kitchen/thor_tasks"
+  Kitchen::ThorTasks.new
+rescue LoadError
+  puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV["CI"]
+end

--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -16,4 +16,5 @@
 # limitations under the License.
 #
 
+default['npm_lazy']['client']['install_nodejs'] = false
 default['npm_lazy']['client']['registry_uri'] = 'http://localhost:8080'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'tsmith84@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures the npm_lazy application for caching NPM registry calls'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 
 depends 'nodejs', '>= 2.0'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe 'nodejs' if node['npm_lazy']['client']['install_nodejs']
+
 # set the npm registry if it's not already set
 execute 'set npm registry' do
   command "npm config set registry #{node['npm_lazy']['client']['registry_uri']}"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -26,15 +26,15 @@ end
 
 nodejs_npm 'npm_lazy'
 
-template '/etc/npm_lazy-config.js' do
-  source 'npm_lazy-config.js.erb'
-  notifies :restart, 'service[npm_lazy]', :immediately
-end
-
 cookbook_file 'etc/init/npm_lazy.conf'
 
 service 'npm_lazy' do
   supports :status => true, :restart => true
   action [:enable, :start]
   provider Chef::Provider::Service::Upstart
+end
+
+template '/etc/npm_lazy-config.js' do
+  source 'npm_lazy-config.js.erb'
+  notifies :restart, 'service[npm_lazy]', :immediately
 end


### PR DESCRIPTION
Thought I could help my throwing a .kitchen.yml in to the project.  It has two suites, client and server to test those recipes respectively.  And added Berksfile as well for dependency management in Test Kitchen to pull in the nodejs cookbook automagically.

For client.rb I added the option to install node like the server recipe had, because node and npm weren't on the ubuntu-14.04 base box.

For the server.rb I had to move the template resource to after the service definition for the converge to run w/o error.

But now you can run a `kitchen converge` and get both boxes running.  No tests yet, but this will make that easier to do going forward.